### PR TITLE
Remove docker tag as already named as required

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -49,7 +49,4 @@ jobs:
             oci-archive:charmed-superset-rock_${tag}_amd64.rock \
             docker-daemon:ghcr.io/canonical/charmed-superset-rock:${tag}
 
-          docker tag \
-            ghcr.io/canonical/charmed-superset-rock:${tag}
-
           docker push ghcr.io/canonical/charmed-superset-rock:${tag}


### PR DESCRIPTION
The publish workflow contained an unnecessary `docker tag` step that is causing errors as there should be 2 arguments. As it's not required due to the naming being applied with skopeo I have removed it.