### PR TITLE
Added Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,42 +14,34 @@ $(foreach var,$(REQUIRED_VARS),\
     $(if $(value $(var)),,$(error $(var) is not set)))
 
 # Targets
-.PHONY: all
-all: install-multipass setup-multipass clone install-prerequisites configure-prerequisites pack run
+.PHONY: all dev build install clean clean-all
 
-.PHONY: dev
+all: dev build install
+
 dev: install-multipass setup-multipass clone install-prerequisites configure-prerequisites
 
-.PHONY: build
 build: pack
 
-.PHONY: install
 install: run
 
-.PHONY: clean
-clean:
-	multipass delete $(ROCK_DEV) && multipass purge
+clean-all:
+	multipass delete -p $(ROCK_DEV)
 
-.PHONY: install-multipass
 install-multipass:
 	sudo snap install multipass
 
-.PHONY: setup-multipass
 setup-multipass:
 	multipass launch $(UBUNTU_VER) -n $(ROCK_DEV) -m 8g -c 2 -d 20G
 
-.PHONY: clone
 clone:
 	multipass exec $(ROCK_DEV) -- git clone $(REPO)
 
-.PHONY: install-prerequisites
 install-prerequisites:
 	multipass exec $(ROCK_DEV) -- bash -c 'sudo snap install rockcraft --edge --classic &&\
 	sudo snap install skopeo --edge --devmode &&\
 	sudo snap install lxd && sudo lxd init --auto'
 	multipass exec $(ROCK_DEV) -- sudo snap install docker
 
-.PHONY: configure-prerequisites
 configure-prerequisites:
 	multipass exec $(ROCK_DEV) -- bash -c 'if getent group docker > /dev/null; then echo "The docker group exists"; else sudo groupadd docker && echo "The docker group has been created"; fi; sudo usermod -aG docker $$USER'
 	multipass exec $(ROCK_DEV) -- bash -c 'sudo snap disable docker && sudo snap enable docker'
@@ -58,7 +50,6 @@ configure-prerequisites:
 pack:
 	multipass exec $(ROCK_DEV) -- bash -c 'cd $(REPO_FOLDER) && rockcraft pack'
 
-.PHONY: run
 run:
 	multipass exec $(ROCK_DEV) -- bash -c 'cd $(REPO_FOLDER) &&\
 		sudo skopeo --insecure-policy copy oci-archive:charmed-superset-rock_$(ROCK_VERSION)-$(UBUNTU_VER)-edge_amd64.rock docker-daemon:charmed-superset-rock:$(ROCK_VERSION)'

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,14 @@ install-multipass:
 	sudo snap install multipass
 
 setup-multipass:
-	multipass launch $(UBUNTU_VER) -n $(ROCK_DEV) -m 8g -c 2 -d 20G
+	@if multipass --format=table list | awk '{print $1}' | grep $(ROCK_DEV); then \
+		echo '$(ROCK_DEV) exists'; \
+	else \
+		multipass launch $(UBUNTU_VER) -n $(ROCK_DEV) -m 8g -c 2 -d 20G; \
+	fi
 
 clone:
-	multipass exec $(ROCK_DEV) -- git clone $(REPO)
+	multipass exec $(ROCK_DEV) -- bash -c '[ -d "$(REPO_FOLDER)/.git" ] || git clone $(REPO)'
 
 install-prerequisites:
 	multipass exec $(ROCK_DEV) -- bash -c 'sudo snap install rockcraft --edge --classic &&\

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,10 @@ configure-prerequisites:
 	multipass exec $(ROCK_DEV) -- bash -c 'if getent group docker > /dev/null; then echo "The docker group exists"; else sudo groupadd docker && echo "The docker group has been created"; fi; sudo usermod -aG docker $$USER'
 	multipass exec $(ROCK_DEV) -- bash -c 'sudo snap disable docker && sudo snap enable docker'
 
-.PHONY: pack
+clean:
+	multipass exec $(ROCK_DEV) -- bash -c 'docker ps -q -f "name=$(DOCKER_NAME)" && docker stop $(DOCKER_NAME) && docker rm $(DOCKER_NAME) && docker rmi charmed-superset-rock:$(ROCK_VERSION)'
+	multipass exec $(ROCK_DEV) -- bash -c 'rm $(REPO_FOLDER)/charmed-superset-rock_$(ROCK_VERSION)-$(UBUNTU_VER)-edge_amd64.rock'
+
 pack:
 	multipass exec $(ROCK_DEV) -- bash -c 'cd $(REPO_FOLDER) && rockcraft pack'
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,56 @@
+# Variables
+REPO_FOLDER = charmed-superset-rock
+REPO = https://github.com/canonical/$(REPO_FOLDER).git
+ROCK_DEV = rock-dev
+ROCK_VERSION = 2.1.0
+DOCKER_NAME = superset-ui-services
+DOCKER_PORT = 8088
+DOCKER_ARGS = superset-ui -g 'daemon off:' \; start superset-ui
+
+# Targets
+.PHONY: all
+all: install-multipass setup-multipass clone install-prerequisites configure-prerequisites pack run
+
+.PHONY: dev
+dev: install-mutipass setup-multipass clone install-prereuisites configure-prerequisites
+
+.PHONY: build
+buid: pack
+
+.PHONY: install
+install: run
+
+.PHONY: install-multipass
+install-multipass:
+	sudo snap install multipass
+
+.PHONY: setup-multipass
+setup-multipass:
+	multipass launch 22.04 -n $(ROCK_DEV)
+
+.PHONY: clone
+clone:
+	multipass exec $(ROCK_DEV) -- git clone $(REPO)
+
+.PHONY: install-prerequisites
+install-prerequisites:
+	multipass exec $(ROCK_DEV) -- sudo snap install rockcraft --edge --classic
+	multipass exec $(ROCK_DEV) -- sudo snap install docker
+	multipass exec $(ROCK_DEV) -- sudo snap install lxd
+	multipass exec $(ROCK_DEV) -- sudo snap install skopeo --edge --devmode
+
+.PHONY: configure-prerequisites
+configure-prerequisites:
+	multipass exec $(ROCK_DEV) -- bash -c 'if getent group docker > /dev/null; then echo "The docker group exists"; else sudo groupadd docker && echo "The docker group has been created"; fi; sudo usermod -aG docker $$USER'
+	multipass exec $(ROCK_DEV) -- sudo lxd init --auto
+
+.PHONY: pack
+pack:
+	multipass exec $(ROCK_DEV) -- bash -c 'cd $(REPO_FOLDER) && rockcraft pack'
+
+.PHONY: run
+run:
+	multipass exec $(ROCK_DEV) -- bash -c 'cd $(REPO_FOLDER) &&\
+		sudo skopeo --insecure-policy copy oci-archive:charmed-superset-rock_$(ROCK_VERSION)_amd64.rock docker-daemon:/charmed-superset-rock:$(ROCK_VERSION)'
+	multipass exec $(ROCK_DEV) -- bash -c 'cd $(REPO_FOLDER) &&\
+	docker run -d --name $(DOCKER_NAME) -p $(DOCKER_PORT):$(DOCKER_PORT) charmed-superset-rock:$(ROCK_VERSION) --args $(DOCKER_ARGS)'

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ DOCKER_NAME = superset-ui-services
 DOCKER_PORT = 8088
 DOCKER_ARGS = superset-ui -g 'daemon off:' \; start superset-ui
 
+REQUIRED_VARS := ROCK_DEV UBUNTU_VER REPO_FOLDER DOCKER_NAME DOCKER_PORT DOCKER_ARGS ROCK_VERSION
+
+$(foreach var,$(REQUIRED_VARS),\
+    $(if $(value $(var)),,$(error $(var) is not set)))
+
 # Targets
 .PHONY: all
 all: install-multipass setup-multipass clone install-prerequisites configure-prerequisites pack run

--- a/Makefile
+++ b/Makefile
@@ -61,4 +61,10 @@ run:
 	multipass exec $(ROCK_DEV) -- bash -c 'cd $(REPO_FOLDER) &&\
 		sudo skopeo --insecure-policy copy oci-archive:charmed-superset-rock_$(ROCK_VERSION)-$(UBUNTU_VER)-edge_amd64.rock docker-daemon:charmed-superset-rock:$(ROCK_VERSION)'
 	multipass exec $(ROCK_DEV) -- bash -c "cd $(REPO_FOLDER) &&\
-	docker run -d --name $(DOCKER_NAME) -p $(DOCKER_PORT):$(DOCKER_PORT) charmed-superset-rock:$(ROCK_VERSION) --args $(DOCKER_ARGS)"
+                docker run -d --name $(DOCKER_NAME) -p $(DOCKER_PORT):$(DOCKER_PORT) charmed-superset-rock:$(ROCK_VERSION) --args $(DOCKER_ARGS)"
+	@IP_ADDRESS=$$(multipass --format=table list | grep $(ROCK_DEV) | awk '{print $$3}') && \
+	echo "Waiting for Superset..."; \
+	while ! nc -z $$IP_ADDRESS $(DOCKER_PORT); do \
+		sleep 1; \
+	done && \
+	echo "Superset is up on $$IP_ADDRESS:$(DOCKER_PORT)"

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ REPO_FOLDER = charmed-superset-rock
 REPO = https://github.com/canonical/$(REPO_FOLDER).git
 ROCK_DEV = rock-dev
 ROCK_VERSION = 2.1.0
+UBUNTU_VER = 22.04
 DOCKER_NAME = superset-ui-services
 DOCKER_PORT = 8088
 DOCKER_ARGS = superset-ui -g 'daemon off:' \; start superset-ui
@@ -12,13 +13,17 @@ DOCKER_ARGS = superset-ui -g 'daemon off:' \; start superset-ui
 all: install-multipass setup-multipass clone install-prerequisites configure-prerequisites pack run
 
 .PHONY: dev
-dev: install-mutipass setup-multipass clone install-prereuisites configure-prerequisites
+dev: install-multipass setup-multipass clone install-prerequisites configure-prerequisites
 
 .PHONY: build
-buid: pack
+build: pack
 
 .PHONY: install
 install: run
+
+.PHONY: clean
+clean:
+	multipass delete $(ROCK_DEV) && multipass purge
 
 .PHONY: install-multipass
 install-multipass:
@@ -26,7 +31,7 @@ install-multipass:
 
 .PHONY: setup-multipass
 setup-multipass:
-	multipass launch 22.04 -n $(ROCK_DEV)
+	multipass launch $(UBUNTU_VER) -n $(ROCK_DEV) -m 8g -c 2 -d 20G
 
 .PHONY: clone
 clone:
@@ -34,15 +39,15 @@ clone:
 
 .PHONY: install-prerequisites
 install-prerequisites:
-	multipass exec $(ROCK_DEV) -- sudo snap install rockcraft --edge --classic
+	multipass exec $(ROCK_DEV) -- bash -c 'sudo snap install rockcraft --edge --classic &&\
+	sudo snap install skopeo --edge --devmode &&\
+	sudo snap install lxd && sudo lxd init --auto'
 	multipass exec $(ROCK_DEV) -- sudo snap install docker
-	multipass exec $(ROCK_DEV) -- sudo snap install lxd
-	multipass exec $(ROCK_DEV) -- sudo snap install skopeo --edge --devmode
 
 .PHONY: configure-prerequisites
 configure-prerequisites:
 	multipass exec $(ROCK_DEV) -- bash -c 'if getent group docker > /dev/null; then echo "The docker group exists"; else sudo groupadd docker && echo "The docker group has been created"; fi; sudo usermod -aG docker $$USER'
-	multipass exec $(ROCK_DEV) -- sudo lxd init --auto
+	multipass exec $(ROCK_DEV) -- bash -c 'sudo snap disable docker && sudo snap enable docker'
 
 .PHONY: pack
 pack:
@@ -51,6 +56,6 @@ pack:
 .PHONY: run
 run:
 	multipass exec $(ROCK_DEV) -- bash -c 'cd $(REPO_FOLDER) &&\
-		sudo skopeo --insecure-policy copy oci-archive:charmed-superset-rock_$(ROCK_VERSION)_amd64.rock docker-daemon:/charmed-superset-rock:$(ROCK_VERSION)'
-	multipass exec $(ROCK_DEV) -- bash -c 'cd $(REPO_FOLDER) &&\
-	docker run -d --name $(DOCKER_NAME) -p $(DOCKER_PORT):$(DOCKER_PORT) charmed-superset-rock:$(ROCK_VERSION) --args $(DOCKER_ARGS)'
+		sudo skopeo --insecure-policy copy oci-archive:charmed-superset-rock_$(ROCK_VERSION)-$(UBUNTU_VER)-edge_amd64.rock docker-daemon:charmed-superset-rock:$(ROCK_VERSION)'
+	multipass exec $(ROCK_DEV) -- bash -c "cd $(REPO_FOLDER) &&\
+	docker run -d --name $(DOCKER_NAME) -p $(DOCKER_PORT):$(DOCKER_PORT) charmed-superset-rock:$(ROCK_VERSION) --args $(DOCKER_ARGS)"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ rock-dev                Running           10.137.215.60    Ubuntu 22.04 LTS
 Navigate to `<VM IP Address>:8088` (in this case 10.137.215.60:8088) and login with `admin`/`admin`. 
 Further information on connecting data sources and creating dashboards can be found at [superset.apache.org](https://superset.apache.org/docs/creating-charts-dashboards/creating-your-first-dashboard/).
 
+## Using Makefile
+
+`make dev` will create the multipass image, clone the repo, install and configure the prerequisites.
+`make build` will pack the rock for you
+`make install` will build the oci image and run it
+`make clean` will remove the image and get you ready to start from `make dev`
+
 ## License
 The Charmed Superset ROCK is free software, distributed under the Apache
 Software License, version 2.0. See

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Further information on connecting data sources and creating dashboards can be fo
 `make dev` will create the multipass image, clone the repo, install and configure the prerequisites.
 `make build` will pack the rock for you
 `make install` will build the oci image and run it
-`make clean` will remove the image and get you ready to start from `make dev`
+`make clean` will remove build artifacts and enable you to rebuild
+`make clean-all` will remove the image and get you ready to start from `make dev`
 
 ## License
 The Charmed Superset ROCK is free software, distributed under the Apache


### PR DESCRIPTION
Translated the README.md file into a Makefile with the targets:

- `dev` for creating image, cloning the repo, installing and configuring prerequisites
- `build` for running `rockcraft pack`
- `install` for building the oci image and running the container
- `clean` for removing image and starting from scratch
- `all` for running the `dev`, `build`, `install` in one go

Arguable good additional targets could be added that allow cleaning the build and the install artifacts only to repeat these processes rather than starting from the beginning.