### PR TITLE
Makes it so only the server initialized the db

### DIFF
--- a/startup-scripts/k8s-bootstrap.sh
+++ b/startup-scripts/k8s-bootstrap.sh
@@ -38,7 +38,6 @@ else
 fi
 
 echo "Initialising superset"
-/app/k8s/k8s-init.sh
 
 if [[ "${CHARM_FUNCTION}" == "worker" ]]; then
   echo "Starting Celery worker..."
@@ -51,5 +50,6 @@ elif [[ "${CHARM_FUNCTION}" == "app" ]]; then
   flask run -p 8088 --with-threads --reload --debugger --host=0.0.0.0
 elif [[ "${CHARM_FUNCTION}" == "app-gunicorn" ]]; then
   echo "Starting web app..."
+  /app/k8s/k8s-init.sh
   /app/k8s/run-server.sh
 fi


### PR DESCRIPTION
The PR makes an update such that only the web server charm initialises the postgresql database. 

Previously the other charm functions (worker and beat) would try to do this and then skip it realising it had already been completed but with Terraform there is no way to ensure charm integration ordering so this should be handled here instead.