### PR TITLE
CSS-6555 Resolve asynchronous queries

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -117,12 +117,13 @@ parts:
       pip install jmespath==1.0.1
 
       # Optional dependencies for Database connectors
-      pip install psycopg2-binary==2.9.9
+      pip install psycopg2-binary==2.9.4
+      pip install sqlalchemy==1.4.51
+      pip install Werkzeug==2.3.7
       pip install Authlib==1.2.1
       pip install elasticsearch-dbapi==0.2.10
       pip install trino==0.327.0
       pip install pyhive==0.7.0
-      pip install SQLALchemy==2.0.23
       pip install thrift==0.16.0
       pip install sqlalchemy-redshift==0.8.1
 


### PR DESCRIPTION
Asynchronous queries is a setting in Superset used to outsource queries in SQL_Lab to the worker rather than server charm. However, when using the ROCK this results in errors on the superset worker due to the version of psycopg2-binary (https://github.com/psycopg/psycopg2/issues/1535 ). This PR reduces the version of psycopg2-binary and depending libraries to resolve this.