### PR TITLE
CSS-6958 Install sentry-sdk for sentry alerting

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -127,6 +127,9 @@ parts:
       pip install thrift==0.16.0
       pip install sqlalchemy-redshift==0.8.1
 
+      # Monitoring
+      pip install sentry-sdk==1.40.0
+
       # Install Superset in editable mode
       pip install -e .
 


### PR DESCRIPTION
To allow for integration with Sentry install the `sentry-sdk` to the charmed-superset-rock