### PR TITLE
Fix urllib3 version so compatible with sentry-sdk

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -126,6 +126,7 @@ parts:
       pip install pyhive==0.7.0
       pip install thrift==0.16.0
       pip install sqlalchemy-redshift==0.8.1
+      pip install urllib3==1.26.11
 
       # Monitoring
       pip install sentry-sdk==1.40.0


### PR DESCRIPTION
The `sentry-sdk` has compatibility issues with the `urllib3` version installed as part of the `pip install -r requirements/base.txt` this PR fixes the version to a compatible one.