### PR TITLE
Reduce sentry-sdk version in line with our sentry version

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -129,7 +129,7 @@ parts:
       pip install urllib3==1.26.11
 
       # Monitoring
-      pip install sentry-sdk==1.40.0
+      pip install sentry-sdk==0.10.2
 
       # Install Superset in editable mode
       pip install -e .


### PR DESCRIPTION
This is a significant reduction in version of the `sentry-sdk` in order to be in line with what we use for collective. The current version of the `sentry-sdk` is not compatible with on premise sentry of version `9.1.2`.