### PR TITLE
Rock refactor

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -17,41 +17,28 @@ services:
     override: replace
     summary: "superset-ui service"
     startup: disabled
-    command: "/app/k8s/k8s-bootstrap.sh"
+    command: "sleep infinity"
+    #command: "/app/k8s/k8s-bootstrap.sh"
     environment:
       CHARM_FUNCTION: "app-gunicorn"
       SUPERSET_SECRET_KEY: "supersetR0cks!"
       ADMIN_PASSWORD: "admin"
       SUPERSET_LOAD_EXAMPLES: True
+  statsd-exporter:
+    override: replace
+    summary: "statsd metrics exporter"
+    startup: disabled
+    command: "/usr/bin/statsd_exporter"
 
 platforms:
   amd64:
 
 parts:
-  backend:
-    plugin: python
+  common:
+    plugin: dump
     source: https://downloads.apache.org/superset/2.1.0/apache-superset-2.1.0-source.tar.gz  # yamllint disable-line
-    source-checksum: sha512/62d240555ea50156fd16ad6dbc6fb26b86ca5319d0528e60cd4fbcb9fbeb9d529acfb43e272883d578df87e609a541a0116dfa8f4a955a3aeca3538adf58852a
+    source-checksum: sha512/62d240555ea50156fd16ad6dbc6fb26b86ca5319d0528e60cd4fbcb9fbeb9d529acfb43e272883d578df87e609a541a0116dfa8f4a955a3aeca3538adf58852a  # yamllint disable-line
     source-type: tar
-    build-packages:
-      - build-essential
-    stage-packages:
-      - python3.10-venv
-    build-environment:
-      - APP_HOME: "/app"
-      - SOURCE: "https://downloads.apache.org/superset"
-      - VERSION: "2.1.0"
-      - TAR_FILE: "apache-superset-2.1.0-source.tar.gz"
-      - DIST_PACKAGES: "usr/local/lib/python3.10/dist-packages/"
-    stage:
-      - apache_superset.egg-info
-      - build
-      - requirements
-      - scripts
-      - setup.cfg
-      - setup.py
-      - superset
-      - superset-frontend
 
   local-files:
     plugin: dump
@@ -68,12 +55,9 @@ parts:
       - requirements/rock-requirements.txt
 
   frontend:
-    after: [backend]
     plugin: nil
     build-snaps:
       - node/14/stable
-    build-environment:
-      - ASSETS_DIR: "/lib/python3.10/site-packages/superset/static/assets"
     override-build: |
       # Prepare for asset creation
       cd ${CRAFT_STAGE}/superset-frontend
@@ -83,42 +67,44 @@ parts:
 
       # Install frontend dependencies and build assets
       npm ci
-      npm run build -- --output-path=/dist
-
-      # Copy assets to CRAFT_PRIME
-      mkdir -p "${CRAFT_PRIME}${ASSETS_DIR}"
-      cp -r /dist/* "${CRAFT_PRIME}${ASSETS_DIR}"
+      npm run build -- --output-path=${CRAFT_PART_INSTALL}/assets
+    organize:
+      assets: lib/python3.10/site-packages/superset/static/assets
+    stage:
+      - lib/python3.10/site-packages/superset/static/assets
 
   gunicorn-app:
-    after: [backend, frontend, local-files]
-    plugin: python
+    after: [common, local-files]
+    plugin: nil
     build-packages:
       - build-essential
       - pkg-config
       - libmysqlclient-dev
     stage-packages:
       - python3.10-venv
-    build-environment:
-      - APP_HOME: "/app"
-      - DIST_PACKAGES: "/usr/local/lib/python3.10/dist-packages"
+      - python3-pip
     override-build: |
-      # Install superset requirements
+      cd ${CRAFT_STAGE}
+
+      # Install Superset requirements
       pip install --upgrade setuptools pip \
-        "cython<3.0.0" \
+        -r requirements/base.txt --target=/dist-packages \
         --no-build-isolation pyyaml==5.4.1 \
-        -r ${CRAFT_STAGE}/requirements/base.txt --target=/${DIST_PACKAGES} \
-        -r ${CRAFT_STAGE}/requirements/rock-requirements.txt --target=/${DIST_PACKAGES}
+        -r requirements/rock-requirements.txt --target=/dist-packages
 
-      # Install Superset in editable mode
-      pip install -e .
-
-      # Copy packages to PRIME
-      mkdir -p ${CRAFT_PART_INSTALL}${DIST_PACKAGES}
-      cp -r ${DIST_PACKAGES}/* ${CRAFT_PART_INSTALL}${DIST_PACKAGES}
-      cp -r . ${CRAFT_PART_INSTALL}${APP_HOME}
+      mv -p /dist-packages ${CRAFT_PART_INSTALL}/usr/local/lib/python3.10/
     stage:
       - usr/local/lib/python3.10/dist-packages
-      - app
+
+  prometheus-statsd-exporter:
+    plugin: dump
+    source: https://github.com/prometheus/statsd_exporter/releases/download/v0.26.1/statsd_exporter-0.26.1.linux-amd64.tar.gz # yamllint disable-line
+    source-checksum: sha256/36b33a04531cf871cf8c9c5d667e3c0ca59c07b4ba496bd6cd066bec4f25cc0d # yamllint disable-line
+    source-type: tar
+    organize:
+      statsd_exporter: bin/statsd_exporter
+    stage:
+      - bin/statsd_exporter
 
   overlay-pkgs:
     plugin: nil

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -17,8 +17,7 @@ services:
     override: replace
     summary: "superset-ui service"
     startup: disabled
-    command: "sleep infinity"
-    #command: "/app/k8s/k8s-bootstrap.sh"
+    command: "/app/k8s/k8s-bootstrap.sh"
     environment:
       CHARM_FUNCTION: "app-gunicorn"
       SUPERSET_SECRET_KEY: "supersetR0cks!"
@@ -33,12 +32,22 @@ services:
 platforms:
   amd64:
 
+# Please refer to
+# https://discourse.ubuntu.com/t/unifying-user-identity-across-snaps-and-rocks/36469
+# for more information about shared user.
+run_user: _daemon_
+
 parts:
-  common:
-    plugin: dump
+  superset:
+    after: [dependencies]
+    plugin: python
     source: https://downloads.apache.org/superset/2.1.0/apache-superset-2.1.0-source.tar.gz  # yamllint disable-line
     source-checksum: sha512/62d240555ea50156fd16ad6dbc6fb26b86ca5319d0528e60cd4fbcb9fbeb9d529acfb43e272883d578df87e609a541a0116dfa8f4a955a3aeca3538adf58852a  # yamllint disable-line
     source-type: tar
+    build-packages:
+      - build-essential
+    stage-packages:
+      - python3.10-venv
 
   local-files:
     plugin: dump
@@ -47,20 +56,32 @@ parts:
       run-server.sh: app/k8s/run-server.sh
       k8s-init.sh: app/k8s/k8s-init.sh
       k8s-bootstrap.sh: app/k8s/k8s-bootstrap.sh
-      rock-requirements.txt: requirements/rock-requirements.txt
+      rock-requirements.txt: requirements/rock.txt
     stage:
       - app/k8s/run-server.sh
       - app/k8s/k8s-init.sh
       - app/k8s/k8s-bootstrap.sh
-      - requirements/rock-requirements.txt
+      - requirements/rock.txt
+    permissions:
+      - path: app/k8s
+        owner: 584792
+        group: 584792
+        mode: "755"
+      - path: requirements
+        owner: 584792
+        group: 584792
+        mode: "755"
 
   frontend:
     plugin: nil
+    source: https://downloads.apache.org/superset/2.1.0/apache-superset-2.1.0-source.tar.gz  # yamllint disable-line
+    source-checksum: sha512/62d240555ea50156fd16ad6dbc6fb26b86ca5319d0528e60cd4fbcb9fbeb9d529acfb43e272883d578df87e609a541a0116dfa8f4a955a3aeca3538adf58852a  # yamllint disable-line
+    source-type: tar
     build-snaps:
       - node/14/stable
     override-build: |
       # Prepare for asset creation
-      cd ${CRAFT_STAGE}/superset-frontend
+      cd superset-frontend
 
       # Install missing frontend dependency
       npm install currencyformatter.js --save
@@ -72,29 +93,43 @@ parts:
       assets: lib/python3.10/site-packages/superset/static/assets
     stage:
       - lib/python3.10/site-packages/superset/static/assets
+    permissions:
+      - path: lib/python3.10/site-packages/superset/static/assets
+        owner: 584792
+        group: 584792
+        mode: "755"
 
-  gunicorn-app:
-    after: [common, local-files]
-    plugin: nil
+  dependencies:
+    after: [local-files]
+    plugin: python
+    source: https://downloads.apache.org/superset/2.1.0/apache-superset-2.1.0-source.tar.gz  # yamllint disable-line
+    source-checksum: sha512/62d240555ea50156fd16ad6dbc6fb26b86ca5319d0528e60cd4fbcb9fbeb9d529acfb43e272883d578df87e609a541a0116dfa8f4a955a3aeca3538adf58852a  # yamllint disable-line
+    source-type: tar
     build-packages:
       - build-essential
       - pkg-config
       - libmysqlclient-dev
     stage-packages:
       - python3.10-venv
-      - python3-pip
     override-build: |
-      cd ${CRAFT_STAGE}
-
       # Install Superset requirements
       pip install --upgrade setuptools pip \
-        -r requirements/base.txt --target=/dist-packages \
         --no-build-isolation pyyaml==5.4.1 \
-        -r requirements/rock-requirements.txt --target=/dist-packages
+        -r requirements/base.txt --target=/${CRAFT_PART_INSTALL}/dist \
+        -r ${CRAFT_STAGE}/requirements/rock.txt --target=/${CRAFT_PART_INSTALL}/dist
 
-      mv -p /dist-packages ${CRAFT_PART_INSTALL}/usr/local/lib/python3.10/
+      # Copy current directory files to app
+      cp -r . ${CRAFT_PART_INSTALL}/app
+    organize:
+      dist: usr/local/lib/python3.10/dist-packages
     stage:
+      - app
       - usr/local/lib/python3.10/dist-packages
+    permissions:
+      - path: usr/local/lib/python3.10/dist-packages
+        owner: 584792
+        group: 584792
+        mode: "755"
 
   prometheus-statsd-exporter:
     plugin: dump
@@ -105,8 +140,14 @@ parts:
       statsd_exporter: bin/statsd_exporter
     stage:
       - bin/statsd_exporter
+    permissions:
+      - path: bin/statsd_exporter
+        owner: 584792
+        group: 584792
+        mode: "755"
 
   overlay-pkgs:
+    after: [superset]
     plugin: nil
     overlay-packages:
       - ca-certificates

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -31,9 +31,10 @@ parts:
   backend:
     plugin: python
     source: https://downloads.apache.org/superset/2.1.0/apache-superset-2.1.0-source.tar.gz  # yamllint disable-line
+    source-checksum: sha512/62d240555ea50156fd16ad6dbc6fb26b86ca5319d0528e60cd4fbcb9fbeb9d529acfb43e272883d578df87e609a541a0116dfa8f4a955a3aeca3538adf58852a
+    source-type: tar
     build-packages:
       - build-essential
-      - wget
     stage-packages:
       - python3.10-venv
     build-environment:
@@ -42,25 +43,15 @@ parts:
       - VERSION: "2.1.0"
       - TAR_FILE: "apache-superset-2.1.0-source.tar.gz"
       - DIST_PACKAGES: "usr/local/lib/python3.10/dist-packages/"
-    override-build: |
-      craftctl default
-      # make home directory
-      mkdir -p ${APP_HOME}
-
-      # Download the Superset tar
-      wget "${SOURCE}/${VERSION}/${TAR_FILE}" -O superset.tar.gz
-
-      # Download the Superset sha512
-      wget "${SOURCE}/${VERSION}/${TAR_FILE}.sha512" -O superset.tar.sha512
-
-      # Validate successful file download
-      sha_file=$(tail -n +2 superset.tar.sha512)
-      hash=$(echo $sha_file | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
-      echo "$hash  superset.tar.gz" | sha512sum --check
-
-      # Unpack tar
-      tar -zxvf superset.tar.gz -C ${APP_HOME} --strip-components 1
-      rm -rf superset.tar.gz
+    stage:
+      - apache_superset.egg-info
+      - build
+      - requirements
+      - scripts
+      - setup.cfg
+      - setup.py
+      - superset
+      - superset-frontend
 
   local-files:
     plugin: dump
@@ -69,18 +60,23 @@ parts:
       run-server.sh: app/k8s/run-server.sh
       k8s-init.sh: app/k8s/k8s-init.sh
       k8s-bootstrap.sh: app/k8s/k8s-bootstrap.sh
+      rock-requirements.txt: requirements/rock-requirements.txt
+    stage:
+      - app/k8s/run-server.sh
+      - app/k8s/k8s-init.sh
+      - app/k8s/k8s-bootstrap.sh
+      - requirements/rock-requirements.txt
 
   frontend:
     after: [backend]
     plugin: nil
-    source: https://downloads.apache.org/superset/2.1.0/apache-superset-2.1.0-source.tar.gz  # yamllint disable-line
     build-snaps:
       - node/14/stable
     build-environment:
       - ASSETS_DIR: "/lib/python3.10/site-packages/superset/static/assets"
     override-build: |
       # Prepare for asset creation
-      cd superset-frontend
+      cd ${CRAFT_STAGE}/superset-frontend
 
       # Install missing frontend dependency
       npm install currencyformatter.js --save
@@ -96,7 +92,6 @@ parts:
   gunicorn-app:
     after: [backend, frontend, local-files]
     plugin: python
-    source: https://downloads.apache.org/superset/2.1.0/apache-superset-2.1.0-source.tar.gz  # yamllint disable-line
     build-packages:
       - build-essential
       - pkg-config
@@ -108,39 +103,22 @@ parts:
       - DIST_PACKAGES: "/usr/local/lib/python3.10/dist-packages"
     override-build: |
       # Install superset requirements
-      pip install --upgrade setuptools pip
-      pip install "cython<3.0.0"
-      pip install --no-build-isolation pyyaml==5.4.1
-      pip install -r requirements/base.txt --target=/${DIST_PACKAGES}
-
-      # Required dependencies missing from Superset requirements.txt
-      pip install Pillow==10.1.0
-      pip install requests==2.31.0
-      pip install jmespath==1.0.1
-
-      # Optional dependencies for Database connectors
-      pip install psycopg2-binary==2.9.4
-      pip install sqlalchemy==1.4.51
-      pip install Werkzeug==2.3.7
-      pip install Authlib==1.2.1
-      pip install elasticsearch-dbapi==0.2.10
-      pip install trino==0.327.0
-      pip install mysqlclient==2.1.1
-      pip install pyhive==0.7.0
-      pip install thrift==0.16.0
-      pip install sqlalchemy-redshift==0.8.1
-      pip install urllib3==1.26.11
-
-      # Monitoring
-      pip install sentry-sdk==0.10.2
+      pip install --upgrade setuptools pip \
+        "cython<3.0.0" \
+        --no-build-isolation pyyaml==5.4.1 \
+        -r ${CRAFT_STAGE}/requirements/base.txt --target=/${DIST_PACKAGES} \
+        -r ${CRAFT_STAGE}/requirements/rock-requirements.txt --target=/${DIST_PACKAGES}
 
       # Install Superset in editable mode
       pip install -e .
 
       # Copy packages to PRIME
-      mkdir -p ${CRAFT_PRIME}${DIST_PACKAGES}
-      cp -r ${DIST_PACKAGES}/* ${CRAFT_PRIME}${DIST_PACKAGES}
-      cp -r . ${CRAFT_PRIME}${APP_HOME}
+      mkdir -p ${CRAFT_PART_INSTALL}${DIST_PACKAGES}
+      cp -r ${DIST_PACKAGES}/* ${CRAFT_PART_INSTALL}${DIST_PACKAGES}
+      cp -r . ${CRAFT_PART_INSTALL}${APP_HOME}
+    stage:
+      - usr/local/lib/python3.10/dist-packages
+      - app
 
   overlay-pkgs:
     plugin: nil

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -35,6 +35,7 @@ platforms:
 # Please refer to
 # https://discourse.ubuntu.com/t/unifying-user-identity-across-snaps-and-rocks/36469
 # for more information about shared user.
+# The UID 584792 corresponds to _daemon_ user.
 run_user: _daemon_
 
 parts:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -115,8 +115,10 @@ parts:
       # Install Superset requirements
       pip install --upgrade setuptools pip \
         --no-build-isolation pyyaml==5.4.1 \
-        -r requirements/base.txt --target=/${CRAFT_PART_INSTALL}/dist \
-        -r ${CRAFT_STAGE}/requirements/rock.txt --target=/${CRAFT_PART_INSTALL}/dist
+        -r requirements/base.txt \
+          --target=/${CRAFT_PART_INSTALL}/dist \
+        -r ${CRAFT_STAGE}/requirements/rock.txt \
+          --target=/${CRAFT_PART_INSTALL}/dist
 
       # Copy current directory files to app
       cp -r . ${CRAFT_PART_INSTALL}/app

--- a/startup-scripts/rock-requirements.txt
+++ b/startup-scripts/rock-requirements.txt
@@ -1,0 +1,18 @@
+# Required dependencies missing from Superset requirements.txt
+Pillow==10.1.0
+requests==2.31.0
+jmespath==1.0.1
+
+# Optional dependencies for Database connectors
+psycopg2-binary==2.9.4
+Authlib==1.2.1
+elasticsearch-dbapi==0.2.10
+trino==0.327.0
+mysqlclient==2.1.1
+pyhive==0.7.0
+thrift==0.16.0
+sqlalchemy-redshift==0.8.1
+
+# Monitoring
+sentry-sdk==0.10.2
+statsd==4.0.1

--- a/startup-scripts/rock-requirements.txt
+++ b/startup-scripts/rock-requirements.txt
@@ -18,6 +18,3 @@ sqlalchemy-redshift==0.8.1
 # Monitoring
 sentry-sdk==0.10.2
 statsd==4.0.1
-
-# Superset
-apache-superset==2.1.0

--- a/startup-scripts/rock-requirements.txt
+++ b/startup-scripts/rock-requirements.txt
@@ -1,4 +1,6 @@
 # Required dependencies missing from Superset requirements.txt
+cython<3.0.0
+pyyaml==5.4.1
 Pillow==10.1.0
 requests==2.31.0
 jmespath==1.0.1
@@ -16,3 +18,6 @@ sqlalchemy-redshift==0.8.1
 # Monitoring
 sentry-sdk==0.10.2
 statsd==4.0.1
+
+# Superset
+apache-superset==2.1.0


### PR DESCRIPTION
Adds:
- Checksums
- Permissions (and run as non root user)
- Staging local files and created assets and packages
- remove unnecessary wget and rely on python plugin instead
- Create a requirements file for rock additional requirements

Note: I thought about creating one part to download the superset tar just the once and then stage this for the other parts to use but this then kind of negates the plugin automated functionality which only applies to the `source`. So I have left it like this for now. 