### PR TITLE
CSS-10732 Copy webfonts to expected directory

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -126,7 +126,7 @@ parts:
   dependencies:
     after: [local-files]
     plugin: python
-    source: https://downloads.apache.org/superset/3.1.3/apache-superset-3.1.3-source.tar.gz   # yamllint disable-line
+    source: https://downloads.apache.org/superset/3.1.3/apache-superset-3.1.3-source.tar.gz  # yamllint disable-line
     source-checksum: sha512/5c35ae761d25fdbd3e1c1dc17d0354b1dd23d98d9c863da7d61b013d59cdb4337cd9e93f8a5b105b657e5d33fa823e138281e8f475dcd20fa0d473e56a00ea7e  # yamllint disable-line
     source-type: tar
     build-packages:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -126,7 +126,7 @@ parts:
   dependencies:
     after: [local-files]
     plugin: python
-    source: https://downloads.apache.org/superset/3.1.3/apache-superset-3.1.3-source.tar.gz  # yamllint disable-line
+    source: https://downloads.apache.org/superset/3.1.3/apache-superset-3.1.3-source.tar.gz   # yamllint disable-line
     source-checksum: sha512/5c35ae761d25fdbd3e1c1dc17d0354b1dd23d98d9c863da7d61b013d59cdb4337cd9e93f8a5b105b657e5d33fa823e138281e8f475dcd20fa0d473e56a00ea7e  # yamllint disable-line
     source-type: tar
     build-packages:
@@ -145,6 +145,11 @@ parts:
 
       # Copy current directory files to app
       cp -r . ${CRAFT_PART_INSTALL}/app
+
+      # Copy webfront images to expected dir
+      cd ${CRAFT_PART_INSTALL}/dist/flask_appbuilder/static/appbuilder/
+      cp -r css/webfonts/ webfonts/
+
     organize:
       dist: usr/local/lib/python3.10/dist-packages
     stage:


### PR DESCRIPTION
The `webfonts` were moved to an unexpected location by the build. Resulting in the screenshotted errors. This is resolved in 4.0.0. For now we can copy the directory to the expected location.
![image](https://github.com/user-attachments/assets/3c6c3590-89dd-44e6-a814-4d3592a47d09)
![Screenshot from 2024-09-13 11-26-08](https://github.com/user-attachments/assets/443723cf-d5aa-45f4-9012-a4533ded6c6f)
