### PR TITLE
CSS-14002: add celery-exporter for exporting worker metrics

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
           rockcraft pack --verbose
 
       - name: Upload locally built ROCK artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: charmed-superset-rock
           path: "charmed-superset-rock_*.rock"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install yq
         run: |
           sudo snap install yq
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: charmed-superset-rock
       - name: Login to GitHub Container Registry

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -176,6 +176,20 @@ parts:
         group: 584792
         mode: "755"
 
+  prometheus-celery-exporter:
+    plugin: dump
+    source: https://github.com/canonical/celery-exporter/releases/download/celery-exporter-chart-0.8.0/celery-exporter # yamllint disable-line
+    source-type: file
+    organize:
+      celery-exporter: bin/celery-exporter
+    stage:
+      - bin/celery-exporter
+    permissions:
+      - path: bin/celery-exporter
+        owner: 584792
+        group: 584792
+        mode: "755"
+
   overlay-pkgs:
     after: [superset]
     plugin: nil


### PR DESCRIPTION
This PR adds `celery-exporter` which is a tool used to export metrics related to celery workers.
This would help us have not only Superset metrics, but also worker metrics.
Potentially we would be alerted when a worker is stuck, even though Superset would show no errors.